### PR TITLE
Added National Bank of Romania provider

### DIFF
--- a/src/Provider/NationalBankOfRomaniaProvider.php
+++ b/src/Provider/NationalBankOfRomaniaProvider.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of Swap.
+ *
+ * (c) Florian Voutzinos <florian@voutzinos.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swap\Provider;
+
+use Swap\Exception\UnsupportedCurrencyPairException;
+use Swap\Model\CurrencyPair;
+use Swap\Model\Rate;
+use Swap\Util\StringUtil;
+
+/**
+ * National Bank of Romania provider.
+ *
+ * @author Mihai Zaharie <mihai@zaharie.ro>
+ */
+class NationalBankOfRomaniaProvider extends AbstractProvider
+{
+    const URL = 'http://www.bnr.ro/nbrfxrates.xml';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchRate(CurrencyPair $currencyPair)
+    {
+        $content = $this->httpAdapter->get(self::URL)->getBody()->getContents();
+
+        $xmlElement = StringUtil::xmlToElement($content);
+
+        $baseCurrency = (string) $xmlElement->Body->OrigCurrency;
+        if ($baseCurrency !== $currencyPair->getBaseCurrency()) {
+            throw new UnsupportedCurrencyPairException($currencyPair);
+        }
+
+        $cube = $xmlElement->Body->Cube;
+        $cubeAttributes = $cube->attributes();
+        $date = new \DateTime((string) $cubeAttributes['date']);
+
+        foreach ($cube->Rate as $rate) {
+            $rateAttributes = $rate->attributes();
+            $rateQuoteCurrency = (string) $rateAttributes['currency'];
+
+            if ($rateQuoteCurrency === $currencyPair->getQuoteCurrency()) {
+                $rateValue = (!empty($rateAttributes['multiplier'])) ? (float) $rate / (int) $rateAttributes['multiplier'] : (float) $rate;
+                return new Rate((string) $rateValue, $date);
+            }
+        }
+
+        throw new UnsupportedCurrencyPairException($currencyPair);
+    }
+}

--- a/tests/Fixtures/Provider/NationalBankOfRomania/nbrfxrates.xml
+++ b/tests/Fixtures/Provider/NationalBankOfRomania/nbrfxrates.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DataSet xmlns="http://www.bnr.ro/xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.bnr.ro/xsd nbrfxrates.xsd">
+    <Header>
+        <Publisher>National Bank of Romania</Publisher>
+        <PublishingDate>2015-01-12</PublishingDate>
+        <MessageType>DR</MessageType>
+    </Header>
+    <Body>
+        <Subject>Reference rates</Subject>
+        <OrigCurrency>RON</OrigCurrency>
+        <Cube date="2015-01-12">
+            <Rate currency="AED">1.0351</Rate>
+            <Rate currency="AUD">3.1054</Rate>
+            <Rate currency="BGN">2.2934</Rate>
+            <Rate currency="BRL">1.4456</Rate>
+            <Rate currency="CAD">3.2006</Rate>
+            <Rate currency="CHF">3.7349</Rate>
+            <Rate currency="CNY">0.6129</Rate>
+            <Rate currency="CZK">0.1580</Rate>
+            <Rate currency="DKK">0.6030</Rate>
+            <Rate currency="EGP">0.5318</Rate>
+            <Rate currency="EUR">4.4856</Rate>
+            <Rate currency="GBP">5.7489</Rate>
+            <Rate currency="HUF" multiplier="100">1.4092</Rate>
+            <Rate currency="INR">0.0611</Rate>
+            <Rate currency="JPY" multiplier="100">3.1895</Rate>
+            <Rate currency="KRW" multiplier="100">0.3501</Rate>
+            <Rate currency="MDL">0.2382</Rate>
+            <Rate currency="MXN">0.2599</Rate>
+            <Rate currency="NOK">0.4914</Rate>
+            <Rate currency="NZD">2.9543</Rate>
+            <Rate currency="PLN">1.0493</Rate>
+            <Rate currency="RSD">0.0365</Rate>
+            <Rate currency="RUB">0.0607</Rate>
+            <Rate currency="SEK">0.4706</Rate>
+            <Rate currency="TRY">1.6609</Rate>
+            <Rate currency="UAH">0.2434</Rate>
+            <Rate currency="USD">3.8023</Rate>
+            <Rate currency="XAU">149.3738</Rate>
+            <Rate currency="XDR">5.4310</Rate>
+            <Rate currency="ZAR">0.3306</Rate>
+        </Cube>
+    </Body>
+</DataSet>

--- a/tests/Tests/Provider/NationalBankOfRomaniaProviderTest.php
+++ b/tests/Tests/Provider/NationalBankOfRomaniaProviderTest.php
@@ -1,0 +1,155 @@
+<?php
+
+/**
+ * This file is part of Swap.
+ *
+ * (c) Florian Voutzinos <florian@voutzinos.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swap\Tests\Provider;
+
+use Swap\Model\CurrencyPair;
+use Swap\Provider\NationalBankOfRomaniaProvider;
+
+class NationalBankOfRomaniaProviderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     * @expectedException \Swap\Exception\UnsupportedCurrencyPairException
+     */
+    public function it_throws_an_exception_when_base_is_not_ron()
+    {
+        $url = 'http://www.bnr.ro/nbrfxrates.xml';
+        $content = file_get_contents(__DIR__ . '/../../Fixtures/Provider/NationalBankOfRomania/nbrfxrates.xml');
+
+        $body = $this->getMock('Psr\Http\Message\StreamableInterface');
+        $body
+            ->expects($this->once())
+            ->method('getContents')
+            ->will($this->returnValue($content));
+
+        $response = $this->getMock('\Ivory\HttpAdapter\Message\ResponseInterface');
+        $response
+            ->expects($this->once())
+            ->method('getBody')
+            ->will($this->returnValue($body));
+
+        $adapter = $this->getMock('Ivory\HttpAdapter\HttpAdapterInterface');
+
+        $adapter
+            ->expects($this->once())
+            ->method('get')
+            ->with($url)
+            ->will($this->returnValue($response));
+
+        $provider = new NationalBankOfRomaniaProvider($adapter);
+        $provider->fetchRate(new CurrencyPair('EUR', 'RON'));
+    }
+
+    /**
+     * @test
+     * @expectedException \Swap\Exception\UnsupportedCurrencyPairException
+     */
+    public function it_throws_an_exception_when_the_pair_is_not_supported()
+    {
+        $url = 'http://www.bnr.ro/nbrfxrates.xml';
+        $content = file_get_contents(__DIR__ . '/../../Fixtures/Provider/NationalBankOfRomania/nbrfxrates.xml');
+
+        $body = $this->getMock('Psr\Http\Message\StreamableInterface');
+        $body
+            ->expects($this->once())
+            ->method('getContents')
+            ->will($this->returnValue($content));
+
+        $response = $this->getMock('\Ivory\HttpAdapter\Message\ResponseInterface');
+        $response
+            ->expects($this->once())
+            ->method('getBody')
+            ->will($this->returnValue($body));
+
+        $adapter = $this->getMock('Ivory\HttpAdapter\HttpAdapterInterface');
+
+        $adapter
+            ->expects($this->once())
+            ->method('get')
+            ->with($url)
+            ->will($this->returnValue($response));
+
+        $provider = new NationalBankOfRomaniaProvider($adapter);
+        $provider->fetchRate(new CurrencyPair('RON', 'XXX'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_fetches_a_rate()
+    {
+        $url = 'http://www.bnr.ro/nbrfxrates.xml';
+        $content = file_get_contents(__DIR__ . '/../../Fixtures/Provider/NationalBankOfRomania/nbrfxrates.xml');
+
+        $body = $this->getMock('Psr\Http\Message\StreamableInterface');
+        $body
+            ->expects($this->once())
+            ->method('getContents')
+            ->will($this->returnValue($content));
+
+        $response = $this->getMock('\Ivory\HttpAdapter\Message\ResponseInterface');
+        $response
+            ->expects($this->once())
+            ->method('getBody')
+            ->will($this->returnValue($body));
+
+        $adapter = $this->getMock('Ivory\HttpAdapter\HttpAdapterInterface');
+
+        $adapter
+            ->expects($this->once())
+            ->method('get')
+            ->with($url)
+            ->will($this->returnValue($response));
+
+        $provider = new NationalBankOfRomaniaProvider($adapter);
+        $rate = $provider->fetchRate(new CurrencyPair('RON', 'EUR'));
+
+        $this->assertSame('4.4856', $rate->getValue());
+        $this->assertEquals(new \DateTime('2015-01-12'), $rate->getDate());
+    }
+
+    /**
+     * @test
+     */
+    public function it_fetches_a_multiplier_rate()
+    {
+        $url = 'http://www.bnr.ro/nbrfxrates.xml';
+        $content = file_get_contents(__DIR__ . '/../../Fixtures/Provider/NationalBankOfRomania/nbrfxrates.xml');
+
+        $body = $this->getMock('Psr\Http\Message\StreamableInterface');
+        $body
+            ->expects($this->once())
+            ->method('getContents')
+            ->will($this->returnValue($content));
+
+        $response = $this->getMock('\Ivory\HttpAdapter\Message\ResponseInterface');
+        $response
+            ->expects($this->once())
+            ->method('getBody')
+            ->will($this->returnValue($body));
+
+        $adapter = $this->getMock('Ivory\HttpAdapter\HttpAdapterInterface');
+
+        $adapter
+            ->expects($this->once())
+            ->method('get')
+            ->with($url)
+            ->will($this->returnValue($response));
+
+        $provider = new NationalBankOfRomaniaProvider($adapter);
+        $rate = $provider->fetchRate(new CurrencyPair('RON', 'HUF'));
+
+        $this->assertSame('0.014092', $rate->getValue());
+        $this->assertEquals(new \DateTime('2015-01-12'), $rate->getDate());
+    }
+}
+


### PR DESCRIPTION
Similar to the European Central Bank provider but the base currency is RON. A multiplier is used for the rates that have subunitary values. [Reference page](http://www.bnr.ro/Cursurile-pietei-valutare-in-format-XML-3424.aspx) (Romanian only).