### PR TITLE
Suppress errors on \DOMDocument::loadHTML() call

### DIFF
--- a/src/Provider/GoogleFinanceProvider.php
+++ b/src/Provider/GoogleFinanceProvider.php
@@ -51,6 +51,9 @@ class GoogleFinanceProvider extends AbstractProvider
         if (!is_numeric($bid)) {
             throw new Exception('The currency is not supported or Google changed the response format');
         }
+		
+		// unsupress the errors to avoid unintended consequences elsewhere
+		libxml_use_internal_errors(FALSE);
 
         return new Rate($bid, new \DateTime());
     }

--- a/src/Provider/GoogleFinanceProvider.php
+++ b/src/Provider/GoogleFinanceProvider.php
@@ -31,7 +31,10 @@ class GoogleFinanceProvider extends AbstractProvider
     {
         $url = sprintf(self::URL, $currencyPair->getBaseCurrency(), $currencyPair->getQuoteCurrency());
         $content = $this->fetchContent($url);
-
+		
+		// To suppress errors on $document->loadHTML($content);
+		libxml_use_internal_errors(TRUE);
+		
         $document = new \DOMDocument();
         @$document->loadHTML($content);
 

--- a/tests/Tests/Provider/GoogleFinanceProviderTest.php
+++ b/tests/Tests/Provider/GoogleFinanceProviderTest.php
@@ -43,4 +43,20 @@ class GoogleFinanceProviderTest extends AbstractProviderTestCase
         $this->assertSame('1.1825', $rate->getValue());
         $this->assertInstanceOf('\DateTime', $rate->getDate());
     }
+	
+	/**
+	 * Asserts that there are no PHP errors/warnings on calls to GoogleFinanceProvider->fetchRate()
+	 * @test
+	 */
+	public function it_has_no_php_errors()
+	{
+		$url = 'http://www.google.com/finance/converter?a=1&from=EUR&to=USD';
+		$content = file_get_contents(__DIR__ . '/../../Fixtures/Provider/GoogleFinance/success.html');
+
+		$provider = new GoogleFinanceProvider($this->getHttpAdapterMock($url, $content));
+		$rate = $provider->fetchRate(new CurrencyPair('EUR', 'USD'));
+
+		// Assert that there was no error during this test
+		$this->assertNull(error_get_last());
+	}
 }


### PR DESCRIPTION
Found a solution at:
http://stackoverflow.com/questions/1685277/warning-domdocumentloadhtml-htmlparseentityref-expecting-in-entity

