### PR TITLE
Use sha1 instead of md5

### DIFF
--- a/src/Model/CurrencyPair.php
+++ b/src/Model/CurrencyPair.php
@@ -100,7 +100,7 @@ final class CurrencyPair
      */
     public function toHash()
     {
-        return md5($this->toString());
+        return sha1($this->toString());
     }
 
     /**


### PR DESCRIPTION
Sha1 has way less change of a conflict. 

This is a BC break (IMO) so we must make it before 3.0