### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,7 @@
 {
     "name": "florianv/swap",
-    "type": "library",
     "description": "Exchange rates library for PHP",
     "keywords": ["currency", "money", "rate", "conversion", "exchange rates"],
-    "homepage": "https://github.com/florianv/swap",
     "license": "MIT",
     "authors": [
         {
@@ -23,11 +21,11 @@
         }
     },
     "require": {
-        "php": "^5.5|^7.0",
+        "php": "^5.5 || ^7.0",
         "florianv/exchanger": "^0.2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "^4.8 || ^5.4",
         "php-http/guzzle6-adapter": "^1.0",
         "php-http/message": "^1.0",
         "psr/cache": "^1.0"


### PR DESCRIPTION
- Removed default homepage url (Packagist will solve this by itself)
- Removed default composer type (library is the default value)
- Switched to new recommended composer syntax ( || )
- Added phpunit support for later php versions