### PR TITLE
Add the option to add services by instance, instead of only by name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Here is the list of the currently implemented services:
 | [Currency Converter API](https://www.currencyconverterapi.com) | * | * | Yes (free but limited or paid) |
 | Array | * | * | Yes |
 
+Additionally, you can add your own services as long as they implement the `ExchangeRateService` interface.
+
 ## Integrations
 
 - A Symfony Bundle [FlorianvSwapBundle](https://github.com/florianv/FlorianvSwapBundle)


### PR DESCRIPTION
This adds the option to add services by instance. This way, one can write small glue code or set up testing implementations using the swap builder. 