### PR TITLE
PHP 8 and PHPUnit 9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
         - php: 7.2
         - php: 7.3
         - php: 7.4
+        - php: 8.0
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
         }
     },
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.1.3 || ^8.0",
         "florianv/exchanger": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5",
+        "phpunit/phpunit": "^7 || ^8 || ^9",
         "php-http/mock-client": "^1.0",
         "php-http/message": "^1.7",
         "nyholm/psr7": "^1.0"

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -28,7 +28,7 @@ class BuilderTest extends TestCase
      */
     private $builder;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -56,12 +56,12 @@ class BuilderTest extends TestCase
         $this->assertInstanceOf(Swap::class, $this->builder->build());
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Client must be an instance of Http\Client\HttpClient or Psr\Http\Client\ClientInterface
-     */
     public function testUseInvalidClient()
     {
+        $this->expectException(\LogicException::class);
+        $expectedExceptionMessage = 'Client must be an instance of Http\Client\HttpClient or Psr\Http\Client\ClientInterface';
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
         $builder = new Builder();
         $builder->useHttpClient(new \stdClass());
     }

--- a/tests/Service/FactoryTest.php
+++ b/tests/Service/FactoryTest.php
@@ -63,7 +63,7 @@ class FactoryTest extends TestCase
             ['xignite', Xignite::class, ['token' => 'token']],
             ['russian_central_bank', RussianCentralBank::class],
             ['cryptonator', Cryptonator::class],
-            ['xchangeapi', XchangeApi::class, ['api-key' => 'api-key']]
+            ['xchangeapi', XchangeApi::class, ['api-key' => 'api-key']],
         ];
     }
 

--- a/tests/Service/FactoryTest.php
+++ b/tests/Service/FactoryTest.php
@@ -28,6 +28,7 @@ use Exchanger\Service\WebserviceX;
 use Exchanger\Service\Xignite;
 use Exchanger\Service\RussianCentralBank;
 use Exchanger\Service\XchangeApi;
+use Http\Discovery\NotFoundException;
 use Http\Mock\Client;
 use PHPUnit\Framework\TestCase;
 use Swap\Service\Factory;
@@ -87,30 +88,30 @@ class FactoryTest extends TestCase
         $this->assertSame($service, $factory->create('baz'));
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Client must be an instance of Http\Client\HttpClient or Psr\Http\Client\ClientInterface
-     */
     public function testConstructInvalidClient()
     {
+        $this->expectException(\LogicException::class);
+        $expectedExceptionMessage = 'Client must be an instance of Http\Client\HttpClient or Psr\Http\Client\ClientInterface';
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
         $factory = new Factory(new \stdClass());
     }
 
-    /**
-     * @expectedException \Http\Discovery\NotFoundException
-     * @expectedExceptionMessage No HTTPlug clients found. Make sure to install a package providing "php-http/client-implementation"
-     */
     public function testWithNullAsClient()
     {
+        $this->expectException(NotFoundException::class);
+        $expectedExceptionMessage = 'No HTTPlug clients found. Make sure to install a package providing "php-http/client-implementation"';
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
         $factory = new Factory();
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Client must be an instance of Http\Client\HttpClient or Psr\Http\Client\ClientInterface
-     */
     public function testSetInvalidClient()
     {
+        $this->expectException(\LogicException::class);
+        $expectedExceptionMessage = 'Client must be an instance of Http\Client\HttpClient or Psr\Http\Client\ClientInterface';
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
         $factory = new Factory(new Client());
         $factory->setHttpClient(new \stdClass());
     }


### PR DESCRIPTION
Upgraded to PHPUnit 9.4; used `$this->expectException()` instead of annotations, fixed inherited method declarations.

Tested with PHP versions: 7.1.33, 7.2.34, 7.3.24, 7.4.12, 8.0.0RC5.

Fixes #135 