### PR TITLE
Add optional `php-http/discovery` to suggested packages to allow auto-discovery work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 /bin/
 /vendor/
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,11 @@
         "phpunit/phpunit": "^7 || ^8 || ^9",
         "php-http/mock-client": "^1.0",
         "php-http/message": "^1.7",
-        "nyholm/psr7": "^1.0"
+        "nyholm/psr7": "^1.0",
+        "php-http/discovery": "^1.0"
+    },
+    "suggest": {
+        "php-http/discovery": "If you are not using `useHttpClient` but instead want to auto-discover HttpClient"
     },
     "scripts": {
         "test": "vendor/bin/phpunit"


### PR DESCRIPTION
Right now the code has a dependency on `php-http/discovery` if you not providing a HttpClient to the `Swap\Builder` using the `useHttpClient` method.
As you can technically use the lib without its dependency I would not add it as a hard dependency but at least suggest it to its users.