### PR TITLE
fix: use explicit nullable types for PHP 8.4 compatibility

### DIFF
--- a/src/Service/Factory.php
+++ b/src/Service/Factory.php
@@ -53,7 +53,7 @@ final class Factory
      * @param HttpClient|ClientInterface|null $httpClient
      * @param RequestFactoryInterface|null    $requestFactory
      */
-    public function __construct($httpClient = null, RequestFactoryInterface $requestFactory = null)
+    public function __construct($httpClient = null, ?RequestFactoryInterface $requestFactory = null)
     {
         if (null === $httpClient) {
             $httpClient = HttpClientDiscovery::find();

--- a/src/Swap.php
+++ b/src/Swap.php
@@ -77,7 +77,7 @@ class Swap
      *
      * @return ExchangeRateContract
      */
-    private function quote(string $currencyPair, \DateTimeInterface $date = null, array $options = []): ExchangeRateContract
+    private function quote(string $currencyPair, ?\DateTimeInterface $date = null, array $options = []): ExchangeRateContract
     {
         $exchangeQueryBuilder = new ExchangeRateQueryBuilder($currencyPair);
 


### PR DESCRIPTION
PHP 8.4 deprecated implicitly nullable parameter types. This change adds explicit `?` nullable type syntax to all affected parameters.

@florianv 
And... it will be nice to have a release :)


BTW: I can be a contributor of the package - I my company we use it on the main project