### PR TITLE
Improve README and discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 
 > _The easy-to-use PHP currency conversion library. Retrieve exchange rates from 30 providers, with caching and fallback. Maintained since 2014._
 
-Swap is a mature PHP **currency conversion library** for retrieving and working with exchange rates. It provides a single, easy-to-use API on top of 30 exchange rate providers, ranging from public sources (the European Central Bank, several national banks, exchangerate.host) to commercial **exchange rate APIs** that require an API key. Caching, historical rates, and a fallback chain are built in. Used in real-world PHP applications since 2014.
+Swap is a mature PHP **currency conversion library** for retrieving and working with exchange rates. It provides a single, easy-to-use API on top of multiple exchange rate providers, ranging from public sources (the European Central Bank, several national banks, exchangerate.host) to commercial **exchange rate APIs** that require an API key. Caching, historical rates, and a fallback chain are built in. Used in real-world PHP applications since 2014.
 
 ## 💡 What is Swap?
 
 - Swap is a PHP library for currency conversion and exchange rate retrieval.
-- It supports 30 exchange rate providers behind a common interface.
+- It exposes a wide range of exchange rate providers behind a common interface.
 - It caches results via PSR-16 SimpleCache.
 - It supports historical rates.
 - It supports a fallback chain. When a provider errors, the next provider in the chain is tried.
@@ -22,16 +22,21 @@ Swap is a mature PHP **currency conversion library** for retrieving and working 
 - Use Swap when you need to retrieve exchange rates in a PHP application: currency conversion workflows, multi-currency pricing, invoice totals, reconciliation, or historical FX data.
 - Use the lower-level [Exchanger](https://github.com/florianv/exchanger) library when Swap's defaults are too opinionated and you want finer control over chain composition, caching, or HTTP plumbing.
 
-## 🧠 Why not call an exchange rate API directly?
+## Why not call an exchange rate API directly?
 
-You can. Here is what Swap does for you so you don't have to build it again:
+You can integrate a single exchange rate API directly in your application.
 
-- **Provider abstraction.** Swap one provider for another without rewriting application code; all 30 providers expose the same interface.
-- **Fallback chain.** Try a primary provider first, fall back to others on error. Unsupported currency pairs are skipped silently.
-- **Caching.** PSR-16 SimpleCache integration with per-query TTL and per-query disable.
-- **Historical rates.** One method (`historical()`) regardless of the underlying endpoint shape.
-- **Typed result objects.** `getValue()`, `getDate()`, `getCurrencyPair()`, `getProviderName()` are uniform across providers, so no per-provider response parsing in your application code.
-- **HTTP plumbing.** PSR-18 / PSR-17 friendly, auto-discovered via `php-http/discovery`. Any compliant HTTP client (Symfony HTTP Client, Guzzle, etc.) works without custom wiring.
+Swap is useful when you need more than a single provider:
+
+- **Provider abstraction** — switch providers without rewriting your code
+- **Fallback support** — if one provider fails, another can be used automatically
+- **Unified interface** — all providers share the same API
+- **Caching** — reduce API calls and improve performance
+- **Flexibility** — combine public and commercial providers
+
+For simple use cases, calling a single API may be enough.
+
+Swap becomes valuable when you need reliability, flexibility, or long-term maintainability.
 
 ## 📦 Installation
 
@@ -103,6 +108,8 @@ All four packages are MIT-licensed and require PHP 8.2 or newer.
 
 ## 📊 Providers
 
+Start with a single provider (for example the European Central Bank), then add others as needed.
+
 Swap supports 30 exchange rate providers via [Exchanger](https://github.com/florianv/exchanger). Pass the **identifier** to `Builder::add()`.
 
 ### Public providers (no API key required)
@@ -173,7 +180,7 @@ The Swap ecosystem:
 - [**Laravel Swap**](https://github.com/florianv/laravel-swap): Laravel application of Swap.
 - [**Symfony Swap**](https://github.com/florianv/symfony-swap): Symfony integration of Swap.
 
-## Sponsorship
+## 🤝 Sponsorship
 
 The Swap ecosystem is open to selected sponsorships from exchange rate API providers and financial infrastructure companies.
 
@@ -185,15 +192,15 @@ Sponsorship can include:
 
 For inquiries, contact the maintainer via [GitHub](https://github.com/florianv).
 
-## Contributing
+## 🙌 Contributing
 
 Issues and pull requests are welcome. Please see the existing [issues](https://github.com/florianv/swap/issues) before opening a new one.
 
-## License
+## 📄 License
 
 The MIT License (MIT). Please see [LICENSE](https://github.com/florianv/swap/blob/master/LICENSE) for more information.
 
-## Credits
+## 👏 Credits
 
 - [Florian Voutzinos](https://github.com/florianv)
 - [All contributors](https://github.com/florianv/swap/contributors)

--- a/README.md
+++ b/README.md
@@ -1,101 +1,199 @@
-# <img src="https://s3.amazonaws.com/swap.assets/swap_logo.png" height="30px" width="30px"/> Swap
+# Swap
 
 [![Tests](https://github.com/florianv/swap/actions/workflows/tests.yml/badge.svg)](https://github.com/florianv/swap/actions/workflows/tests.yml)
 [![Psalm](https://github.com/florianv/swap/actions/workflows/psalm.yml/badge.svg)](https://github.com/florianv/swap/actions/workflows/psalm.yml)
 [![Total Downloads](https://img.shields.io/packagist/dt/florianv/swap.svg?style=flat-square)](https://packagist.org/packages/florianv/swap)
 [![Version](http://img.shields.io/packagist/v/florianv/swap.svg?style=flat-square)](https://packagist.org/packages/florianv/swap)
 
-Swap allows you to retrieve currency exchange rates from various services such as **[Fixer](https://fixer.io/)**, **[Currency Data](https://currencylayer.com)** or **[Exchange Rates Data](https://exchangeratesapi.io/)** and optionally cache the results. 
-It is integrated to other libraries like [moneyphp/money](https://github.com/moneyphp/money) and provides
-a [Symfony Bundle](https://github.com/florianv/FlorianvSwapBundle) and a [Laravel Package](https://github.com/florianv/laravel-swap).
+> _The easy-to-use PHP currency conversion library. Retrieve exchange rates from 30 providers, with caching and fallback. Maintained since 2014._
 
-## QuickStart
+Swap is a mature PHP **currency conversion library** for retrieving and working with exchange rates. It provides a single, easy-to-use API on top of 30 exchange rate providers, ranging from public sources (the European Central Bank, several national banks, exchangerate.host) to commercial **exchange rate APIs** that require an API key. Caching, historical rates, and a fallback chain are built in. Used in real-world PHP applications since 2014.
+
+## What is Swap?
+
+- Swap is a PHP library for currency conversion and exchange rate retrieval.
+- It supports 30 exchange rate providers behind a common interface.
+- It caches results via PSR-16 SimpleCache.
+- It supports historical rates.
+- It supports a fallback chain. When a provider errors, the next provider in the chain is tried.
+
+## When should you use Swap?
+
+- Use Swap when you need to retrieve exchange rates in a PHP application: currency conversion workflows, multi-currency pricing, invoice totals, reconciliation, or historical FX data.
+- Use the lower-level [Exchanger](https://github.com/florianv/exchanger) library when Swap's defaults are too opinionated and you want finer control over chain composition, caching, or HTTP plumbing.
+
+## Why not call an exchange rate API directly?
+
+You can. Here is what Swap does for you so you don't have to build it again:
+
+- **Provider abstraction.** Swap one provider for another without rewriting application code; all 30 providers expose the same interface.
+- **Fallback chain.** Try a primary provider first, fall back to others on error. Unsupported currency pairs are skipped silently.
+- **Caching.** PSR-16 SimpleCache integration with per-query TTL and per-query disable.
+- **Historical rates.** One method (`historical()`) regardless of the underlying endpoint shape.
+- **Typed result objects.** `getValue()`, `getDate()`, `getCurrencyPair()`, `getProviderName()` are uniform across providers, so no per-provider response parsing in your application code.
+- **HTTP plumbing.** PSR-18 / PSR-17 friendly, auto-discovered via `php-http/discovery`. Any compliant HTTP client (Symfony HTTP Client, Guzzle, etc.) works without custom wiring.
+
+## Installation
+
+Swap requires PHP 8.2 or newer.
 
 ```bash
-$ composer require php-http/curl-client nyholm/psr7 php-http/message florianv/swap
+composer require florianv/swap symfony/http-client nyholm/psr7
 ```
+
+`symfony/http-client` is the PSR-18 HTTP client and `nyholm/psr7` provides the PSR-17 factories. Any PSR-18 / PSR-17 implementation works (see the [documentation](doc/readme.md) for alternatives such as Guzzle).
+
+## Quickstart
 
 ```php
 use Swap\Builder;
 
-// Build Swap
+// Build Swap with the European Central Bank (free, no API key required).
 $swap = (new Builder())
+    ->add('european_central_bank')
+    ->build();
 
-    // Use the Fixer service as first level provider
-    ->add('apilayer_fixer', ['api_key' => 'Get your key here: https://fixer.io/'])
-     
-    // Use the currencylayer service as first fallback
-    ->add('apilayer_currency_data', ['api_key' => 'Get your key here: https://currencylayer.com'])
-    
-    // Use the exchangerates service as second fallback
-    ->add('apilayer_exchange_rates_data', ['api_key' => 'Get your key here: https://exchangeratesapi.io/'])
-->build();
-    
-// Get the latest EUR/USD rate
+// EUR → USD exchange rate
 $rate = $swap->latest('EUR/USD');
 
-// 1.129
-$rate->getValue();
+$rate->getValue();                 // e.g. 1.0823 (a float)
+$rate->getDate()->format('Y-m-d'); // e.g. 2026-04-29
+$rate->getProviderName();          // 'european_central_bank'
 
-// 2016-08-26
-$rate->getDate()->format('Y-m-d');
+// Convert an amount using the returned rate
+$amountInEUR  = 100.00;
+$amountInUSD  = $amountInEUR * $rate->getValue();
 
-// Get the EUR/USD rate 15 days ago
-$rate = $swap->historical('EUR/USD', (new \DateTime())->modify('-15 days'));
+// Retrieve a historical rate
+$past = $swap->historical('EUR/USD', new \DateTime('-15 days'));
 ```
+
+Swap retrieves the rate; your application multiplies the amount by `$rate->getValue()` to perform the conversion.
+
+## Configuring multiple providers (fallback chain)
+
+```php
+$swap = (new Builder())
+    ->add('your_primary_provider', ['api_key' => 'YOUR_KEY']) // see Providers below
+    ->add('your_fallback_provider', ['api_key' => 'YOUR_KEY'])
+    ->add('european_central_bank') // free fallback for EUR-base pairs
+    ->build();
+```
+
+Providers are tried in order. If a provider does not support the requested currency pair, it is skipped silently. If a provider throws an error, the next provider is tried. If every provider fails, a `ChainException` is thrown with all collected errors.
+
+## Common use cases
+
+- Display localized prices in multi-currency storefronts.
+- Compute invoice totals across currencies.
+- Reconcile multi-currency ledgers using historical rates.
+- Power internal FX dashboards with rate history.
+- Build currency conversion infrastructure for fintech and ERP applications.
+
+## Which package should I use?
+
+The Swap ecosystem is a layered toolkit for currency conversion in PHP:
+
+- **Swap.** The easy-to-use, high-level API (this package).
+- **Exchanger.** Lower-level, more granular alternative; direct access to the 30 provider implementations and the `ExchangeRateService` interface.
+- **Laravel Swap.** Laravel application of Swap.
+- **Symfony Swap.** Symfony integration of Swap.
+
+All four packages are MIT-licensed and require PHP 8.2 or newer.
+
+## Providers
+
+Swap supports 30 exchange rate providers via [Exchanger](https://github.com/florianv/exchanger). Pass the **identifier** to `Builder::add()`.
+
+### Public providers (no API key required)
+
+| Service                                    | Identifier                            | Base           | Quote          | Historical |
+| ------------------------------------------ | ------------------------------------- | -------------- | -------------- | ---------- |
+| Bulgarian National Bank                    | `bulgarian_national_bank`             | *              | BGN            | Yes        |
+| Central Bank of the Czech Republic         | `central_bank_of_czech_republic`      | *              | CZK            | Yes        |
+| Central Bank of the Republic of Turkey     | `central_bank_of_republic_turkey`     | *              | TRY            | Yes        |
+| Central Bank of the Republic of Uzbekistan | `central_bank_of_republic_uzbekistan` | *              | UZS            | Yes        |
+| Cryptonator                                | `cryptonator`                         | * (crypto)     | * (crypto)     | No         |
+| European Central Bank                      | `european_central_bank`               | EUR            | *              | Yes        |
+| exchangerate.host                          | `exchangeratehost`                    | *              | *              | Yes        |
+| National Bank of Georgia                   | `national_bank_of_georgia`            | *              | GEL            | Yes        |
+| National Bank of Romania                   | `national_bank_of_romania`            | (limited list) | (limited list) | Yes        |
+| National Bank of the Republic of Belarus   | `national_bank_of_republic_belarus`   | *              | BYN            | Yes        |
+| National Bank of Ukraine                   | `national_bank_of_ukraine`            | *              | UAH            | Yes        |
+| Russian Central Bank                       | `russian_central_bank`                | *              | RUB            | Yes        |
+| WebserviceX                                | `webservicex`                         | *              | *              | No         |
+
+### Commercial providers (require an API key)
+
+| Service                         | Identifier                     | Base                 | Quote | Historical |
+| ------------------------------- | ------------------------------ | -------------------- | ----- | ---------- |
+| AbstractAPI                     | `abstract_api`                 | *                    | *     | Yes        |
+| coinlayer                       | `coin_layer`                   | * (crypto)           | *     | Yes        |
+| Currency Converter API          | `currency_converter`           | *                    | *     | Yes        |
+| Currency Data (APILayer)        | `apilayer_currency_data`       | USD (free), * (paid) | *     | Yes        |
+| CurrencyDataFeed                | `currency_data_feed`           | *                    | *     | No         |
+| currencylayer (direct)          | `currency_layer`               | USD (free), * (paid) | *     | Yes        |
+| Exchange Rates Data (APILayer)  | `apilayer_exchange_rates_data` | USD (free), * (paid) | *     | Yes        |
+| exchangeratesapi (direct)       | `exchange_rates_api`           | USD (free), * (paid) | *     | Yes        |
+| fastFOREX.io                    | `fastforex`                    | USD (free), * (paid) | *     | No         |
+| Fixer (APILayer)                | `apilayer_fixer`               | EUR (free), * (paid) | *     | Yes        |
+| Fixer (direct)                  | `fixer`                        | EUR (free), * (paid) | *     | Yes        |
+| 1Forge                          | `forge`                        | *                    | *     | No         |
+| Open Exchange Rates             | `open_exchange_rates`          | USD (free), * (paid) | *     | Yes        |
+| xChangeApi.com                  | `xchangeapi`                   | *                    | *     | Yes        |
+| Xignite                         | `xignite`                      | *                    | *     | Yes        |
+
+You can also add your own provider by implementing the `Exchanger\Contract\ExchangeRateService` interface and passing the instance to `Builder::addExchangeRateService()`.
+
+## Caching, HTTP client, and error handling
+
+- **Caching.** Swap uses PSR-16 `SimpleCache`. Configure once on the builder:
+
+  ```php
+  $swap = (new Builder())->useSimpleCache($psr16Cache)->add('european_central_bank')->build();
+  ```
+
+  Disable caching for a single query: `$swap->latest('EUR/USD', ['cache' => false])`.
+  Override the TTL for a single query: `$swap->latest('EUR/USD', ['cache_ttl' => 3600])`.
+
+- **HTTP client.** Any PSR-18 client (`symfony/http-client`, `php-http/guzzle7-adapter`, etc.) is supported and auto-discovered via `php-http/discovery`. To pass an explicit instance, use `Builder::useHttpClient()`.
+
+- **Errors.** When every configured provider has either skipped (unsupported pair) or thrown, Swap raises an `Exchanger\Exception\ChainException` containing all collected exceptions.
 
 ## Documentation
 
-The documentation for the current branch can be found [here](https://github.com/florianv/swap/blob/master/doc/readme.md).
+The full documentation is in [`doc/readme.md`](doc/readme.md), and is also published at [florianv.github.io/swap](https://florianv.github.io/swap/).
 
-## Services
+## Related packages
 
-Here is the list of the currently implemented services:
+The Swap ecosystem:
 
-| Service | Base Currency | Quote Currency | Historical |
-|---------------------------------------------------------------------------|----------------------|----------------|----------------|
-| [Fixer](https://fixer.io/) | EUR (free, no SSL), * (paid) | * | Yes |
-| [Currency Data](https://currencylayer.com) | USD (free), * (paid) | * | Yes |
-| [Exchange Rates Data](https://exchangeratesapi.io/) | USD (free), * (paid) | * | Yes |
-| [Abstract](https://www.abstractapi.com) | * | * | Yes |
-| [coinlayer](https://coinlayer.com) | * Crypto (Limited standard currencies) | * Crypto (Limited standard currencies) | Yes |
-| [Fixer](https://fixer.io) | EUR (free, no SSL), * (paid) | * | Yes |
-| [Currency Data](https://currencylayer.com) | USD (free), * (paid) | * | Yes |
-| [exchangeratesapi](https://exchangeratesapi.io) | USD (free), * (paid) | * | Yes |
-| [European Central Bank](https://www.ecb.europa.eu/home/html/index.en.html) | EUR | * | Yes |
-| [National Bank of Georgia](https://nbg.gov.ge) | * | GEL | Yes |
-| [National Bank of the Republic of Belarus](https://www.nbrb.by) | * | BYN (from 01-07-2016),<br>BYR (01-01-2000 - 30-06-2016),<br>BYB (25-05-1992 - 31-12-1999) | Yes |
-| [National Bank of Romania](http://www.bnr.ro) | RON, AED, AUD, BGN, BRL, CAD, CHF, CNY, CZK, DKK, EGP, EUR, GBP, HRK, HUF, INR, JPY, KRW, MDL, MXN, NOK, NZD, PLN, RSD, RUB, SEK, TRY, UAH, USD, XAU, XDR, ZAR | RON, AED, AUD, BGN, BRL, CAD, CHF, CNY, CZK, DKK, EGP, EUR, GBP, HRK, HUF, INR, JPY, KRW, MDL, MXN, NOK, NZD, PLN, RSD, RUB, SEK, TRY, UAH, USD, XAU, XDR, ZAR | Yes |
-| [National Bank of Ukranie](https://bank.gov.ua) | * | UAH | Yes |
-| [Central Bank of the Republic of Turkey](http://www.tcmb.gov.tr) | * | TRY | Yes |
-| [Central Bank of the Republic of Uzbekistan](https://cbu.uz) | * | UZS | Yes |
-| [Central Bank of the Czech Republic](https://www.cnb.cz) | * | CZK | Yes |
-| [Central Bank of Russia](https://cbr.ru) | * | RUB | Yes |
-| [Bulgarian National Bank](http://bnb.bg) | * | BGN | Yes |
-| [WebserviceX](http://www.webservicex.net) | * | * | No |
-| [1Forge](https://1forge.com) | * (free but limited or paid) | * (free but limited or paid) | No |
-| [Cryptonator](https://www.cryptonator.com) | * Crypto (Limited standard currencies) | * Crypto (Limited standard currencies)  | No |
-| [CurrencyDataFeed](https://currencydatafeed.com) | * (free but limited or paid) | * (free but limited or paid) | No |
-| [Open Exchange Rates](https://openexchangerates.org) | USD (free), * (paid) | * | Yes |
-| [Xignite](https://www.xignite.com) | * | * | Yes |
-| [Currency Converter API](https://www.currencyconverterapi.com) | * | * | Yes (free but limited or paid) |
-| [xChangeApi.com](https://xchangeapi.com) | * | * | Yes |
-| [fastFOREX.io](https://www.fastforex.io) | USD (free), * (paid) | * | No |
-| [exchangerate.host](https://www.exchangerate.host) | * | * | Yes |
-| Array | * | * | Yes |
+- [**Swap**](https://github.com/florianv/swap): easy-to-use PHP currency conversion library.
+- [**Exchanger**](https://github.com/florianv/exchanger): lower-level, more granular alternative; direct access to provider implementations.
+- [**Laravel Swap**](https://github.com/florianv/laravel-swap): Laravel application of Swap.
+- [**Symfony Swap**](https://github.com/florianv/symfony-swap): Symfony integration of Swap.
 
-Additionally, you can add your own services as long as they implement the `ExchangeRateService` interface.
+## Sponsorship
 
-## Integrations
+The Swap ecosystem is open to selected sponsorships from exchange rate API providers and financial infrastructure companies.
 
-- A Symfony Bundle [FlorianvSwapBundle](https://github.com/florianv/FlorianvSwapBundle)
-- A Laravel Package [florianv/laravel-swap](https://github.com/florianv/laravel-swap)
+Sponsorship can include:
 
-## Credits
+- Documentation visibility
+- Integration examples
+- Ecosystem-level visibility across Swap, Exchanger, Laravel Swap, and Symfony Swap
 
-- [Florian Voutzinos](https://github.com/florianv)
-- [All Contributors](https://github.com/florianv/swap/contributors)
+For inquiries, contact the maintainer via [GitHub](https://github.com/florianv).
+
+## Contributing
+
+Issues and pull requests are welcome. Please see the existing [issues](https://github.com/florianv/swap/issues) before opening a new one.
 
 ## License
 
 The MIT License (MIT). Please see [LICENSE](https://github.com/florianv/swap/blob/master/LICENSE) for more information.
+
+## Credits
+
+- [Florian Voutzinos](https://github.com/florianv)
+- [All contributors](https://github.com/florianv/swap/contributors)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Swap is a mature PHP **currency conversion library** for retrieving and working with exchange rates. It provides a single, easy-to-use API on top of 30 exchange rate providers, ranging from public sources (the European Central Bank, several national banks, exchangerate.host) to commercial **exchange rate APIs** that require an API key. Caching, historical rates, and a fallback chain are built in. Used in real-world PHP applications since 2014.
 
-## What is Swap?
+## 💡 What is Swap?
 
 - Swap is a PHP library for currency conversion and exchange rate retrieval.
 - It supports 30 exchange rate providers behind a common interface.
@@ -17,12 +17,12 @@ Swap is a mature PHP **currency conversion library** for retrieving and working 
 - It supports historical rates.
 - It supports a fallback chain. When a provider errors, the next provider in the chain is tried.
 
-## When should you use Swap?
+## 🎯 When should you use Swap?
 
 - Use Swap when you need to retrieve exchange rates in a PHP application: currency conversion workflows, multi-currency pricing, invoice totals, reconciliation, or historical FX data.
 - Use the lower-level [Exchanger](https://github.com/florianv/exchanger) library when Swap's defaults are too opinionated and you want finer control over chain composition, caching, or HTTP plumbing.
 
-## Why not call an exchange rate API directly?
+## 🧠 Why not call an exchange rate API directly?
 
 You can. Here is what Swap does for you so you don't have to build it again:
 
@@ -33,7 +33,7 @@ You can. Here is what Swap does for you so you don't have to build it again:
 - **Typed result objects.** `getValue()`, `getDate()`, `getCurrencyPair()`, `getProviderName()` are uniform across providers, so no per-provider response parsing in your application code.
 - **HTTP plumbing.** PSR-18 / PSR-17 friendly, auto-discovered via `php-http/discovery`. Any compliant HTTP client (Symfony HTTP Client, Guzzle, etc.) works without custom wiring.
 
-## Installation
+## 📦 Installation
 
 Swap requires PHP 8.2 or newer.
 
@@ -43,7 +43,7 @@ composer require florianv/swap symfony/http-client nyholm/psr7
 
 `symfony/http-client` is the PSR-18 HTTP client and `nyholm/psr7` provides the PSR-17 factories. Any PSR-18 / PSR-17 implementation works (see the [documentation](doc/readme.md) for alternatives such as Guzzle).
 
-## Quickstart
+## ⚡ Quickstart
 
 ```php
 use Swap\Builder;
@@ -70,7 +70,7 @@ $past = $swap->historical('EUR/USD', new \DateTime('-15 days'));
 
 Swap retrieves the rate; your application multiplies the amount by `$rate->getValue()` to perform the conversion.
 
-## Configuring multiple providers (fallback chain)
+## 🔁 Configuring multiple providers (fallback chain)
 
 ```php
 $swap = (new Builder())
@@ -82,7 +82,7 @@ $swap = (new Builder())
 
 Providers are tried in order. If a provider does not support the requested currency pair, it is skipped silently. If a provider throws an error, the next provider is tried. If every provider fails, a `ChainException` is thrown with all collected errors.
 
-## Common use cases
+## 🛠 Common use cases
 
 - Display localized prices in multi-currency storefronts.
 - Compute invoice totals across currencies.
@@ -90,7 +90,7 @@ Providers are tried in order. If a provider does not support the requested curre
 - Power internal FX dashboards with rate history.
 - Build currency conversion infrastructure for fintech and ERP applications.
 
-## Which package should I use?
+## 🧭 Which package should I use?
 
 The Swap ecosystem is a layered toolkit for currency conversion in PHP:
 
@@ -101,7 +101,7 @@ The Swap ecosystem is a layered toolkit for currency conversion in PHP:
 
 All four packages are MIT-licensed and require PHP 8.2 or newer.
 
-## Providers
+## 📊 Providers
 
 Swap supports 30 exchange rate providers via [Exchanger](https://github.com/florianv/exchanger). Pass the **identifier** to `Builder::add()`.
 
@@ -145,7 +145,7 @@ Swap supports 30 exchange rate providers via [Exchanger](https://github.com/flor
 
 You can also add your own provider by implementing the `Exchanger\Contract\ExchangeRateService` interface and passing the instance to `Builder::addExchangeRateService()`.
 
-## Caching, HTTP client, and error handling
+## ⚙ Caching, HTTP client, and error handling
 
 - **Caching.** Swap uses PSR-16 `SimpleCache`. Configure once on the builder:
 
@@ -160,11 +160,11 @@ You can also add your own provider by implementing the `Exchanger\Contract\Excha
 
 - **Errors.** When every configured provider has either skipped (unsupported pair) or thrown, Swap raises an `Exchanger\Exception\ChainException` containing all collected exceptions.
 
-## Documentation
+## 📚 Documentation
 
 The full documentation is in [`doc/readme.md`](doc/readme.md), and is also published at [florianv.github.io/swap](https://florianv.github.io/swap/).
 
-## Related packages
+## 🧩 Related packages
 
 The Swap ecosystem:
 

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,19 @@
 {
     "name": "florianv/swap",
-    "description": "Exchange rates library for PHP",
+    "description": "PHP currency conversion library for retrieving exchange rates from 30 providers, with caching and fallback.",
     "license": "MIT",
     "keywords": [
         "currency",
         "money",
         "rate",
         "conversion",
-        "exchange rates"
+        "exchange rates",
+        "currency conversion",
+        "currency conversion library",
+        "php currency conversion",
+        "exchange rate api",
+        "forex",
+        "forex api"
     ],
     "authors": [
         {

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -1,88 +1,101 @@
 # Documentation
 
-## Sponsors
+## 📘 About this documentation
 
-<table>
-   <tr>
-      <td><img src="https://assets.apilayer.com/apis/fixer.png" width="50px"/></td>
-      <td><a href="https://fixer.io/">Fixer</a> is a simple and lightweight API for foreign exchange rates that supports up to 170 world currencies.</td>
-   </tr>
-   <tr>
-     <td><img src="https://assets.apilayer.com/apis/currency_data.png" width="50px"/></td>
-     <td><a href="https://currencylayer.com">currencylayer</a> provides reliable exchange rates and currency conversions for your business up to 168 world currencies.</td>
-   </tr>
-   <tr>
-     <td><img src="https://assets.apilayer.com/apis/exchangerates_data.png" width="50px"/></td>
-     <td><a href="https://exchangeratesapi.io/">exchangerates</a> provides reliable exchange rates and currency conversions for your business with over 15 data sources.</td>
-   </tr>   
-</table>
+This documentation covers the practical use of Swap, the PHP currency conversion library: configuration, caching, provider configuration, and how to write your own provider. For an overview of the library and the wider ecosystem (Exchanger, Laravel Swap, Symfony Swap), see the [README](../README.md).
 
 ## Index
+
 * [Installation](#installation)
 * [Configuration](#configuration)
+  * [Building Swap](#building-swap)
+  * [Adding multiple providers](#adding-multiple-providers)
+  * [How the fallback chain works](#how-the-fallback-chain-works)
 * [Usage](#usage)
-  * [Retrieving Rates](#retrieving-rates)
-  * [Rate Provider](#rate-provider)
-* [Cache](#cache)
- * [Rates Caching](#rates-caching)
- * [Query Cache Options](#query-cache-options)
- * [Requests Caching](#requests-caching)
-* [Creating a Service](#creating-a-service)
-  * [Standard Service](#standard-service)
-  * [Historical Service](#historical-service)
-* [Supported Services](#supported-services)  
-  
-## Installation
+  * [Retrieving rates](#retrieving-rates)
+  * [Inspecting the rate](#inspecting-the-rate)
+* [Caching](#caching)
+  * [PSR-16 SimpleCache (minimal setup)](#psr-16-simplecache-minimal-setup)
+  * [Per-query options](#per-query-options)
+  * [HTTP request caching](#http-request-caching)
+* [Provider configuration](#provider-configuration)
+* [Creating a custom service](#creating-a-custom-service)
+  * [Standard service](#standard-service)
+  * [Historical service](#historical-service)
+* [FAQ](#faq)
 
-Swap is decoupled from any library sending HTTP requests (like Guzzle), instead it uses an abstraction called [HTTPlug](http://httplug.io/) 
-which provides the http layer used to send requests to exchange rate services. 
-This gives you the flexibility to choose what HTTP client and PSR-7 implementation you want to use.
+## 📦 Installation
 
-Read more about the benefits of this and about what different HTTP clients you may use in the [HTTPlug documentation](http://docs.php-http.org/en/latest/httplug/users.html). 
-Below is an example using the curl client:
+Swap requires PHP 8.2 or newer. It does not bundle an HTTP client; any PSR-18 client paired with a PSR-17 request factory works, and `php-http/discovery` finds them automatically.
+
+The simplest modern install:
 
 ```bash
-composer require php-http/curl-client nyholm/psr7 php-http/message florianv/swap
+composer require florianv/swap symfony/http-client nyholm/psr7
 ```
 
-## Configuration
+Other PSR-18 clients work the same way, for example Guzzle 7:
 
-Before starting to retrieve currency exchange rates, we need to build `Swap`. Fortunately, the `Builder` class helps us to perform this task.
+```bash
+composer require florianv/swap php-http/guzzle7-adapter nyholm/psr7
+```
 
-Let's say we want to use the [Fixer](https://fixer.io/) service and fallback to [currencylayer](https://currencylayer.com) in case of failure. 
-We would write the following:
+You can also pass a client explicitly via `Builder::useHttpClient()` if you do not want auto-discovery.
+
+## ⚙ Configuration
+
+### Building Swap
+
+`Swap` is built with the `Builder` class. The minimal case uses a single, free provider:
 
 ```php
 use Swap\Builder;
 
 $swap = (new Builder())
-    ->add('apilayer_fixer', ['api_key' => 'Get your key here: https://fixer.io/'])
-    ->add('apilayer_currency_data', ['api_key' => 'Get your key here: https://currencylayer.com'])
-    ->add('apilayer_exchange_rates_data', ['api_key' => 'Get your key here: https://exchangeratesapi.io/'])
-->build();
+    ->add('european_central_bank')
+    ->build();
 ```
 
-As you can see, you can use the `add()` method to add a service. You can add as many as you want, they will be called in a chain, in case of failure.
+`add()` registers a provider by its identifier (the string passed to `Builder::add()`, for example `european_central_bank`). The full list of identifiers is in the README's [Providers table](../README.md#providers).
 
-We recommend to use one of the [services that support our project](#sponsors), providing a free plan up to 100 requests per month.
+### Adding multiple providers
 
-The complete list of all supported services is available [here](#supported-services).
+You can chain several providers. Each one is configured with its own options array:
 
-## Usage
+```php
+use Swap\Builder;
 
-### Retrieving Rates
+$swap = (new Builder())
+    ->add('your_primary_provider', ['api_key' => 'YOUR_KEY'])
+    ->add('your_fallback_provider', ['api_key' => 'YOUR_KEY'])
+    ->add('european_central_bank') // free fallback for EUR-base pairs
+    ->build();
+```
 
-In order to get rates, you can use the `latest()` or `historical()` methods on `Swap`:
+Identifiers and the configuration keys each one accepts are documented in the [Provider configuration](#provider-configuration) section.
+
+### How the fallback chain works
+
+Swap calls providers in declaration order. For each provider:
+
+1. If the provider does not support the requested currency pair, it is skipped silently.
+2. If the provider throws an exception, the exception is collected and the next provider is tried.
+3. If a provider returns a rate, that rate is returned to the caller and the remaining providers are not called.
+
+If every provider was skipped or threw, Swap raises an `Exchanger\Exception\ChainException` containing all collected exceptions. The chain does not retry the same provider, and there is no built-in delay between attempts.
+
+## ⚡ Usage
+
+### Retrieving rates
+
+`Swap` exposes two methods, `latest()` for the most recent rate and `historical()` for a rate on a given date:
 
 ```php
 // Latest rate
 $rate = $swap->latest('EUR/USD');
 
-// 1.129
-echo $rate->getValue();
-
-// 2016-08-26
-echo $rate->getDate()->format('Y-m-d');
+echo $rate->getValue();                 // e.g. 1.0823
+echo $rate->getDate()->format('Y-m-d'); // e.g. 2026-04-29
 
 // Historical rate
 $rate = $swap->historical('EUR/USD', (new \DateTime())->modify('-15 days'));
@@ -90,139 +103,192 @@ $rate = $swap->historical('EUR/USD', (new \DateTime())->modify('-15 days'));
 
 > Currencies are expressed as their [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) code.
 
-### Rate provider
+Both methods accept an options array as a third argument; see [Per-query options](#per-query-options) for the supported keys.
 
-When using the chain service, it can be useful to know which service provided the rate.
+### Inspecting the rate
 
-You can use the `getProviderName()` function on a rate that gives you the name of the service that returned it:
+The returned `Exchanger\Contract\ExchangeRate` exposes:
 
 ```php
-$name = $rate->getProviderName();
+$rate->getValue();         // float
+$rate->getDate();          // DateTimeInterface
+$rate->getCurrencyPair();  // Exchanger\CurrencyPair
+$rate->getProviderName();  // string, the identifier that returned the rate
 ```
 
-For example, if Fixer returned the rate, it will be identical to `fixer`.
+`getProviderName()` is useful when several providers are chained: the returned value is the identifier of the provider that actually answered, for example `european_central_bank`.
 
-## Cache
+## 💾 Caching
 
-### Rates Caching
+### PSR-16 SimpleCache (minimal setup)
 
-`Exchanger` provides a [PSR-16 Simple Cache](http://www.php-fig.org/psr/psr-16) integration allowing you to cache rates during a given time using the adapter of your choice.
+Swap caches results through a PSR-16 `SimpleCache`. Any PSR-16 implementation works. A minimal Symfony Cache example:
 
-The following example uses the `Predis` cache from [php-cache.com](http://php-cache.com) PSR-6 implementation installable using `composer require cache/predis-adapter`.
-
-You will also need to install a "bridge" that allows to adapt the PSR-6 adapters to PSR-16 using `composer require cache/simple-cache-bridge` (https://github.com/php-cache/simple-cache-bridge).
- 
 ```bash
- $ composer require cache/predis-adapter
- ```
+composer require symfony/cache
+```
+
+```php
+use Swap\Builder;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Psr16Cache;
+
+$cache = new Psr16Cache(new FilesystemAdapter());
+
+$swap = (new Builder(['cache_ttl' => 3600, 'cache_key_prefix' => 'myapp-']))
+    ->useSimpleCache($cache)
+    ->add('european_central_bank')
+    ->build();
+```
+
+All rates returned by Swap are now cached for 3600 seconds, keyed with the prefix `myapp-`.
+
+If only PSR-6 adapters are available, you can bridge them to PSR-16 with [`cache/simple-cache-bridge`](https://github.com/php-cache/simple-cache-bridge). For example with Predis:
+
+```bash
+composer require cache/predis-adapter cache/simple-cache-bridge
+```
 
 ```php
 use Cache\Adapter\Predis\PredisCachePool;
 use Cache\Bridge\SimpleCache\SimpleCacheBridge;
 
-$client = new \Predis\Client('tcp:/127.0.0.1:6379');
-$psr6pool = new PredisCachePool($client);
-$simpleCache = new SimpleCacheBridge($psr6pool);
-
-$swap = (new Builder(['cache_ttl' => 3600, 'cache_key_prefix' => 'myapp-']))
-    ->useSimpleCache($simpleCache)
-    ->build();
+$client = new \Predis\Client('tcp://127.0.0.1:6379');
+$cache  = new SimpleCacheBridge(new PredisCachePool($client));
 ```
 
-All rates will now be cached in Redis during 3600 seconds, and cache keys will be prefixed with 'myapp-'
+### Per-query options
 
-### Query Cache Options
+Cache behavior can be overridden per call.
 
-You can override `Swap` caching options per request.
+#### `cache_ttl`
 
-#### cache_ttl
-
-Set cache TTL in seconds. Default: `null` - cache entries permanently
+Cache TTL in seconds. Default: `null` (cache entries do not expire).
 
 ```php
-// Override the global cache_ttl only for this query
 $rate = $swap->latest('EUR/USD', ['cache_ttl' => 60]);
 $rate = $swap->historical('EUR/USD', $date, ['cache_ttl' => 60]);
 ```
 
-#### cache
+#### `cache`
 
-Disable/Enable caching. Default: `true`
+Disable or enable caching for a single query. Default: `true`.
 
 ```php
-// Disable caching for this query
 $rate = $swap->latest('EUR/USD', ['cache' => false]);
 $rate = $swap->historical('EUR/USD', $date, ['cache' => false]);
 ```
 
-#### cache_key_prefix
+#### `cache_key_prefix`
 
-Set the cache key prefix. Default: empty string
+Override the cache key prefix for a single query. Default: empty string.
 
-There is a limitation of 64 characters for the key length in PSR-6, because of this, key prefix must not exceed 24 characters, as sha1() hash takes 40 symbols.
-
-PSR-6 do not allows characters `{}()/\@:` in key, these characters are replaced with `-`
+PSR-6 limits cache keys to 64 characters. The internal hash of the query takes 40 characters, so the prefix must not exceed 24 characters. PSR-6 also does not allow the characters `{}()/\@:` in keys; Swap replaces them with `-`.
 
 ```php
-// Override cache key prefix for this query
 $rate = $swap->latest('EUR/USD', ['cache_key_prefix' => 'currencies-special-']);
 $rate = $swap->historical('EUR/USD', $date, ['cache_key_prefix' => 'currencies-special-']);
 ```
 
-### Requests Caching
+### HTTP request caching
 
-By default, `Swap` queries the service for each rate you request, but some services like `Fixer` sends a whole file containing
-rates for each base currency. 
+Some providers return all rates for a given base currency in a single response. If you fetch several pairs sharing the same base (for example `EUR/USD` and then `EUR/GBP`), caching the underlying HTTP response avoids hitting the provider twice.
 
-It means that if you are requesting multiple rates using the same base currency like `EUR/USD`, then `EUR/GBP`, you may want
-to cache these responses in order to improve performances.
-
-#### Example
-
-Install the PHP HTTP Cache plugin and the PHP Cache Array adapter.
+Install the PHP HTTP cache plugin and a PSR-6 cache adapter:
 
 ```bash
-$ composer require php-http/cache-plugin cache/array-adapter
+composer require php-http/cache-plugin cache/array-adapter
 ```
 
-Modify the way you create your HTTP Client by decorating it with a `PluginClient` using the `Array` cache:
+Decorate your HTTP client with the cache plugin and pass it to `Builder::useHttpClient()`:
 
 ```php
-use Http\Client\Common\PluginClient;
-use Http\Client\Common\Plugin\CachePlugin;
-use Http\Message\StreamFactory\GuzzleStreamFactory;
-use Http\Adapter\Guzzle6\Client as GuzzleClient;
 use Cache\Adapter\PHPArray\ArrayCachePool;
+use Http\Adapter\Guzzle7\Client as GuzzleClient;
+use Http\Client\Common\Plugin\CachePlugin;
+use Http\Client\Common\PluginClient;
+use Http\Message\StreamFactory\GuzzleStreamFactory;
 use Swap\Builder;
 
-$pool = new ArrayCachePool();
+$pool          = new ArrayCachePool();
 $streamFactory = new GuzzleStreamFactory();
-$cachePlugin = new CachePlugin($pool, $streamFactory);
-$client = new PluginClient(new GuzzleClient(), [$cachePlugin]);
+$cachePlugin   = new CachePlugin($pool, $streamFactory);
+$client        = new PluginClient(new GuzzleClient(), [$cachePlugin]);
 
 $swap = (new Builder())
     ->useHttpClient($client)
-    ->add('apilayer_fixer', ['api_key' => 'Get your key here: https://fixer.io/'])
-    ->add('apilayer_currency_data', ['api_key' => 'Get your key here: https://currencylayer.com'])
-    ->add('apilayer_exchange_rates_data', ['api_key' => 'Get your key here: https://exchangeratesapi.io/'])
+    ->add('european_central_bank')
     ->build();
 
-// A http request is sent
+// First call performs an HTTP request
 $rate = $swap->latest('EUR/USD');
 
-// A new request won't be sent
+// Second call hits the HTTP cache
 $rate = $swap->latest('EUR/GBP');
 ```
 
-## Creating a Service
+## 🔑 Provider configuration
 
-You want to add a new service to `Swap` ? Great!
+Public providers (central banks, national banks, `cryptonator`, `exchangeratehost`, `webservicex`) need no configuration. Add them by identifier:
 
-If your service must send http requests to retrieve rates, your class must extend the `HttpService` class, otherwise you can extend the more generic `Service` class.
+```php
+$swap = (new Builder())
+    ->add('european_central_bank')
+    ->add('national_bank_of_romania')
+    ->build();
+```
+
+Commercial providers require an API key. The option name varies by provider:
+
+| Identifier                       | Required option | Optional flags        |
+| -------------------------------- | --------------- | --------------------- |
+| `abstract_api`                   | `api_key`       |                       |
+| `apilayer_currency_data`         | `api_key`       |                       |
+| `apilayer_exchange_rates_data`   | `api_key`       |                       |
+| `apilayer_fixer`                 | `api_key`       |                       |
+| `coin_layer`                     | `access_key`    | `paid` (bool)         |
+| `currency_converter`             | `access_key`    | `enterprise` (bool)   |
+| `currency_data_feed`             | `api_key`       |                       |
+| `currency_layer`                 | `access_key`    | `enterprise` (bool)   |
+| `exchange_rates_api`             | `access_key`    |                       |
+| `fastforex`                      | `api_key`       |                       |
+| `fixer`                          | `access_key`    |                       |
+| `fixer_apilayer`                 | `api_key`       |                       |
+| `forge`                          | `api_key`       |                       |
+| `open_exchange_rates`            | `app_id`        | `enterprise` (bool)   |
+| `xchangeapi`                     | `api-key`       | (note the hyphen)     |
+| `xignite`                        | `token`         |                       |
+
+Example:
+
+```php
+$swap = (new Builder())
+    ->add('apilayer_fixer',      ['api_key'    => 'YOUR_KEY'])
+    ->add('open_exchange_rates', ['app_id'     => 'YOUR_APP_ID', 'enterprise' => false])
+    ->add('xignite',             ['token'      => 'YOUR_TOKEN'])
+    ->build();
+```
+
+The `array` provider is a special case used in tests and fixtures. It accepts a nested structure of latest and historical rates:
+
+```php
+$swap = (new Builder())
+    ->add('array', [
+        ['EUR/USD' => 1.1, 'EUR/GBP' => 1.5],          // latest rates
+        ['2017-01-01' => ['EUR/USD' => 1.5]],          // historical rates
+    ])
+    ->build();
+```
+
+The full provider list with capabilities (base currency, quote currency, historical support) is in the README's [Providers table](../README.md#providers).
+
+## 🧩 Creating a custom service
+
+You can register your own provider as long as it implements the same contract used internally. If your service makes HTTP requests, extend `Exchanger\Service\HttpService`; otherwise extend the simpler `Exchanger\Service\Service`.
 
 ### Standard service
 
-In the following example, we are creating a `Constant` service that returns a constant rate value.
+The example below registers a `Constant` service that returns a fixed rate value:
 
 ```php
 use Exchanger\Contract\ExchangeRateQuery;
@@ -232,28 +298,14 @@ use Swap\Service\Registry;
 
 class ConstantService extends HttpService
 {
-    /**
-     * Gets the exchange rate.
-     *
-     * @param ExchangeRateQuery $exchangeQuery
-     *
-     * @return ExchangeRate
-     */
     public function getExchangeRate(ExchangeRateQuery $exchangeQuery): ExchangeRate
     {
-        // If you want to make a request you can use
-        // $content = $this->request('http://example.com');
+        // To call an HTTP endpoint:
+        // $content = $this->request('https://example.com');
 
         return $this->createInstantRate($exchangeQuery->getCurrencyPair(), $this->options['value']);
     }
 
-    /**
-     * Processes the service options.
-     *
-     * @param array &$options
-     *
-     * @return void
-     */
     public function processOptions(array &$options): void
     {
         if (!isset($options['value'])) {
@@ -261,124 +313,77 @@ class ConstantService extends HttpService
         }
     }
 
-    /**
-     * Tells if the service supports the exchange rate query.
-     *
-     * @param ExchangeRateQuery $exchangeQuery
-     *
-     * @return bool
-     */
     public function supportQuery(ExchangeRateQuery $exchangeQuery): bool
     {
-        // For example, our service only supports EUR as base currency
+        // Example: only support EUR-base pairs.
         return 'EUR' === $exchangeQuery->getCurrencyPair()->getBaseCurrency();
     }
 
-    /**
-     * Gets the name of the exchange rate service.
-     *
-     * @return string
-     */
     public function getName(): string
     {
         return 'constant';
     }
 }
 
-// Register the service so it's available using Builder::add()
+// Register the service so Builder::add() recognizes its identifier
 Registry::register('constant', ConstantService::class);
 
-// Now you can use the add() method add your service name and pass your options
 $swap = (new Builder())
     ->add('constant', ['value' => 10])
     ->build();
 
-// 10
-echo $swap->latest('EUR/USD')->getValue();
+echo $swap->latest('EUR/USD')->getValue(); // 10
 ```
 
 ### Historical service
 
-If your service supports retrieving historical rates, you need to use the `SupportsHistoricalQueries` trait.
-
-You will need to rename the `getExchangeRate` method to `getLatestExchangeRate` and switch its visibility to protected, and implement a new `getHistoricalExchangeRate` method:
+To support historical rates, use the `SupportsHistoricalQueries` trait. Rename `getExchangeRate` to `getLatestExchangeRate` (now `protected`) and implement `getHistoricalExchangeRate`:
 
 ```php
+use Exchanger\Contract\ExchangeRateQuery;
+use Exchanger\Contract\ExchangeRate;
+use Exchanger\HistoricalExchangeRateQuery;
+use Exchanger\Service\HttpService;
 use Exchanger\Service\SupportsHistoricalQueries;
 
 class ConstantService extends HttpService
 {
     use SupportsHistoricalQueries;
-    
-    /**
-     * Gets the exchange rate.
-     *
-     * @param ExchangeRateQuery $exchangeQuery
-     *
-     * @return ExchangeRate
-     */
+
     protected function getLatestExchangeRate(ExchangeRateQuery $exchangeQuery): ExchangeRate
     {
         return $this->createInstantRate($exchangeQuery->getCurrencyPair(), $this->options['value']);
     }
 
-    /**
-     * Gets an historical rate.
-     *
-     * @param HistoricalExchangeRateQuery $exchangeQuery
-     *
-     * @return ExchangeRate
-     */
     protected function getHistoricalExchangeRate(HistoricalExchangeRateQuery $exchangeQuery): ExchangeRate
     {
         return $this->createInstantRate($exchangeQuery->getCurrencyPair(), $this->options['value']);
     }
-}    
+}
 ```
 
-## Supported Services
+## ❓ FAQ
 
-Here is the complete list of supported services and their possible configurations:
+#### What happens when every provider fails?
 
-```php
-use Swap\Builder;
+Swap throws an `Exchanger\Exception\ChainException`. Calling `$exception->getExceptions()` on it returns the list of exceptions collected from each provider in the chain.
 
-$swap = (new Builder())
-    ->add('apilayer_fixer', ['api_key' => 'Get your key here: https://fixer.io/'])
-    ->add('apilayer_currency_data', ['api_key' => 'Get your key here: https://currencylayer.com'])
-    ->add('apilayer_exchange_rates_data', ['api_key' => 'Get your key here: https://exchangeratesapi.io/'])
-    ->add('abstract_api', ['api_key' => 'Get your key here: https://app.abstractapi.com/users/signup'])
-    ->add('coin_layer', ['access_key' => 'secret', 'paid' => false])
-    ->add('fixer', ['access_key' => 'your-access-key'])
-    ->add('currency_layer', ['access_key' => 'secret', 'enterprise' => false])
-    ->add('exchange_rates_api', ['access_key' => 'secret'])
-    ->add('european_central_bank')
-    ->add('national_bank_of_romania')
-    ->add('central_bank_of_republic_turkey')
-    ->add('central_bank_of_czech_republic')
-    ->add('russian_central_bank')
-    ->add('bulgarian_national_bank')
-    ->add('webservicex')
-    ->add('forge', ['api_key' => 'secret'])
-    ->add('cryptonator')
-    ->add('currency_data_feed', ['api_key' => 'secret'])
-    ->add('currency_converter', ['access_key' => 'secret', 'enterprise' => false])
-    ->add('open_exchange_rates', ['app_id' => 'secret', 'enterprise' => false])
-    ->add('xignite', ['token' => 'token'])
-    ->add('xchangeapi', ['api-key' => 'secret'])
-    ->add('array', [
-        [
-            'EUR/USD' => 1.1,
-            'EUR/GBP' => 1.5
-        ],
-        [
-            '2017-01-01' => [
-                'EUR/USD' => 1.5
-            ],
-            '2017-01-03' => [
-                'EUR/GBP' => 1.3
-            ],
-        ]
-    ])
-    ->build();
-```
+#### Can I use Swap without an API key?
+
+Yes. The European Central Bank, the national banks, `cryptonator`, `exchangeratehost`, and `webservicex` do not require an API key. See the [Providers table](../README.md#providers) for the full list.
+
+#### How do I cache rates?
+
+Configure any PSR-16 cache via `Builder::useSimpleCache()`. See [PSR-16 SimpleCache (minimal setup)](#psr-16-simplecache-minimal-setup).
+
+#### How do I disable cache for a single query?
+
+Pass `['cache' => false]` as the options argument: `$swap->latest('EUR/USD', ['cache' => false])`.
+
+#### How do I add my own provider?
+
+Implement `Exchanger\Contract\ExchangeRateService` (or extend `HttpService` / `Service`), register it with `Swap\Service\Registry::register()`, then call `Builder::add()` with your identifier. See [Creating a custom service](#creating-a-custom-service).
+
+#### Where is the full provider list with capabilities?
+
+In the README's [Providers table](../README.md#providers). It lists every supported identifier with its base currency, quote currency, and historical support.

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -1,28 +1,55 @@
 # Documentation
 
-## 📘 About this documentation
+## 💡 What is Swap?
 
-This documentation covers the practical use of Swap, the PHP currency conversion library: configuration, caching, provider configuration, and how to write your own provider. For an overview of the library and the wider ecosystem (Exchanger, Laravel Swap, Symfony Swap), see the [README](../README.md).
+- Swap is a PHP library for currency conversion and exchange rate retrieval.
+- It exposes a wide range of exchange rate providers behind a common interface.
+- It caches results via PSR-16 SimpleCache.
+- It supports historical rates.
+- It supports a fallback chain. When a provider errors, the next provider in the chain is tried.
+
+For the wider ecosystem (Exchanger, Laravel Swap, Symfony Swap), see the [README](../README.md).
+
+## 🎯 When should you use Swap?
+
+- Use Swap when you need to retrieve exchange rates in a PHP application: currency conversion workflows, multi-currency pricing, invoice totals, reconciliation, or historical FX data.
+- Use the lower-level [Exchanger](https://github.com/florianv/exchanger) library when Swap's defaults are too opinionated and you want finer control over chain composition, caching, or HTTP plumbing.
+
+## 🧠 Why not call an exchange rate API directly?
+
+You can integrate a single exchange rate API directly in your application.
+
+Swap is useful when you need more than a single provider:
+
+- **Provider abstraction** — switch providers without rewriting your code
+- **Fallback support** — if one provider fails, another can be used automatically
+- **Unified interface** — all providers share the same API
+- **Caching** — reduce API calls and improve performance
+- **Flexibility** — combine public and commercial providers
+
+For simple use cases, calling a single API may be enough.
+
+Swap becomes valuable when you need reliability, flexibility, or long-term maintainability.
 
 ## Index
 
-* [Installation](#installation)
-* [Configuration](#configuration)
+* [Installation](#-installation)
+* [Configuration](#-configuration)
   * [Building Swap](#building-swap)
   * [Adding multiple providers](#adding-multiple-providers)
   * [How the fallback chain works](#how-the-fallback-chain-works)
-* [Usage](#usage)
+* [Usage](#-usage)
   * [Retrieving rates](#retrieving-rates)
   * [Inspecting the rate](#inspecting-the-rate)
-* [Caching](#caching)
+* [Caching](#-caching)
   * [PSR-16 SimpleCache (minimal setup)](#psr-16-simplecache-minimal-setup)
   * [Per-query options](#per-query-options)
   * [HTTP request caching](#http-request-caching)
-* [Provider configuration](#provider-configuration)
-* [Creating a custom service](#creating-a-custom-service)
+* [Provider configuration](#-provider-configuration)
+* [Creating a custom service](#-creating-a-custom-service)
   * [Standard service](#standard-service)
   * [Historical service](#historical-service)
-* [FAQ](#faq)
+* [FAQ](#-faq)
 
 ## 📦 Installation
 
@@ -56,7 +83,7 @@ $swap = (new Builder())
     ->build();
 ```
 
-`add()` registers a provider by its identifier (the string passed to `Builder::add()`, for example `european_central_bank`). The full list of identifiers is in the README's [Providers table](../README.md#providers).
+`add()` registers a provider by its identifier (the string passed to `Builder::add()`, for example `european_central_bank`). The full list of identifiers is in the README's [Providers table](../README.md#-providers).
 
 ### Adding multiple providers
 
@@ -72,7 +99,7 @@ $swap = (new Builder())
     ->build();
 ```
 
-Identifiers and the configuration keys each one accepts are documented in the [Provider configuration](#provider-configuration) section.
+Identifiers and the configuration keys each one accepts are documented in the [Provider configuration](#-provider-configuration) section.
 
 ### How the fallback chain works
 
@@ -159,48 +186,29 @@ $cache  = new SimpleCacheBridge(new PredisCachePool($client));
 
 ### Per-query options
 
-Cache behavior can be overridden per call.
+Cache behavior can be overridden per call by passing an options array to `latest()` or `historical()`.
 
-#### `cache_ttl`
+| Option             | Type   | Default | Effect                                                                                                |
+| ------------------ | ------ | ------- | ----------------------------------------------------------------------------------------------------- |
+| `cache_ttl`        | int    | `null`  | Cache TTL in seconds. `null` means entries do not expire.                                             |
+| `cache`            | bool   | `true`  | Set to `false` to bypass the cache for this call.                                                     |
+| `cache_key_prefix` | string | `""`    | Prefix for the cache key. Max 24 characters (PSR-6 limits keys to 64 chars; the internal hash takes 40). |
 
-Cache TTL in seconds. Default: `null` (cache entries do not expire).
-
-```php
-$rate = $swap->latest('EUR/USD', ['cache_ttl' => 60]);
-$rate = $swap->historical('EUR/USD', $date, ['cache_ttl' => 60]);
-```
-
-#### `cache`
-
-Disable or enable caching for a single query. Default: `true`.
+PSR-6 does not allow the characters `{}()/\@:` in keys; Swap replaces them with `-`.
 
 ```php
 $rate = $swap->latest('EUR/USD', ['cache' => false]);
-$rate = $swap->historical('EUR/USD', $date, ['cache' => false]);
-```
-
-#### `cache_key_prefix`
-
-Override the cache key prefix for a single query. Default: empty string.
-
-PSR-6 limits cache keys to 64 characters. The internal hash of the query takes 40 characters, so the prefix must not exceed 24 characters. PSR-6 also does not allow the characters `{}()/\@:` in keys; Swap replaces them with `-`.
-
-```php
+$rate = $swap->latest('EUR/USD', ['cache_ttl' => 60]);
 $rate = $swap->latest('EUR/USD', ['cache_key_prefix' => 'currencies-special-']);
-$rate = $swap->historical('EUR/USD', $date, ['cache_key_prefix' => 'currencies-special-']);
 ```
 
 ### HTTP request caching
 
-Some providers return all rates for a given base currency in a single response. If you fetch several pairs sharing the same base (for example `EUR/USD` and then `EUR/GBP`), caching the underlying HTTP response avoids hitting the provider twice.
-
-Install the PHP HTTP cache plugin and a PSR-6 cache adapter:
+Some providers return all rates for a given base currency in a single response. If you fetch several pairs sharing the same base (for example `EUR/USD` and then `EUR/GBP`), caching the underlying HTTP response avoids hitting the provider twice. Decorate your HTTP client with the PHP HTTP cache plugin and pass it to `Builder::useHttpClient()`:
 
 ```bash
 composer require php-http/cache-plugin cache/array-adapter
 ```
-
-Decorate your HTTP client with the cache plugin and pass it to `Builder::useHttpClient()`:
 
 ```php
 use Cache\Adapter\PHPArray\ArrayCachePool;
@@ -220,11 +228,8 @@ $swap = (new Builder())
     ->add('european_central_bank')
     ->build();
 
-// First call performs an HTTP request
-$rate = $swap->latest('EUR/USD');
-
-// Second call hits the HTTP cache
-$rate = $swap->latest('EUR/GBP');
+$rate = $swap->latest('EUR/USD'); // performs an HTTP request
+$rate = $swap->latest('EUR/GBP'); // hits the HTTP cache
 ```
 
 ## 🔑 Provider configuration
@@ -263,9 +268,9 @@ Example:
 
 ```php
 $swap = (new Builder())
-    ->add('apilayer_fixer',      ['api_key'    => 'YOUR_KEY'])
-    ->add('open_exchange_rates', ['app_id'     => 'YOUR_APP_ID', 'enterprise' => false])
-    ->add('xignite',             ['token'      => 'YOUR_TOKEN'])
+    ->add('apilayer_fixer',      ['api_key' => 'YOUR_KEY'])
+    ->add('open_exchange_rates', ['app_id'  => 'YOUR_APP_ID', 'enterprise' => false])
+    ->add('xignite',             ['token'   => 'YOUR_TOKEN'])
     ->build();
 ```
 
@@ -280,7 +285,7 @@ $swap = (new Builder())
     ->build();
 ```
 
-The full provider list with capabilities (base currency, quote currency, historical support) is in the README's [Providers table](../README.md#providers).
+The full provider list with capabilities (base currency, quote currency, historical support) is in the README's [Providers table](../README.md#-providers).
 
 ## 🧩 Creating a custom service
 
@@ -370,7 +375,11 @@ Swap throws an `Exchanger\Exception\ChainException`. Calling `$exception->getExc
 
 #### Can I use Swap without an API key?
 
-Yes. The European Central Bank, the national banks, `cryptonator`, `exchangeratehost`, and `webservicex` do not require an API key. See the [Providers table](../README.md#providers) for the full list.
+Yes. The European Central Bank, the national banks, `cryptonator`, `exchangeratehost`, and `webservicex` do not require an API key. See the [Providers table](../README.md#-providers) for the full list.
+
+#### How does Swap relate to Exchanger?
+
+Swap is the high-level, easy-to-use API. Exchanger is the lower-level provider layer Swap is built on. Reach for Exchanger directly only when you need finer control over chain composition, caching, or HTTP plumbing. See the README's [Which package should I use?](../README.md#-which-package-should-i-use) section.
 
 #### How do I cache rates?
 
@@ -382,8 +391,8 @@ Pass `['cache' => false]` as the options argument: `$swap->latest('EUR/USD', ['c
 
 #### How do I add my own provider?
 
-Implement `Exchanger\Contract\ExchangeRateService` (or extend `HttpService` / `Service`), register it with `Swap\Service\Registry::register()`, then call `Builder::add()` with your identifier. See [Creating a custom service](#creating-a-custom-service).
+Implement `Exchanger\Contract\ExchangeRateService` (or extend `HttpService` / `Service`), register it with `Swap\Service\Registry::register()`, then call `Builder::add()` with your identifier. See [Creating a custom service](#-creating-a-custom-service).
 
 #### Where is the full provider list with capabilities?
 
-In the README's [Providers table](../README.md#providers). It lists every supported identifier with its base currency, quote currency, and historical support.
+In the README's [Providers table](../README.md#-providers). It lists every supported identifier with its base currency, quote currency, and historical support.


### PR DESCRIPTION
## What changed

### README

- Rewrote the README around a clearer value proposition with new sections (*What is Swap?*, *When should you use Swap?*, *Why not call an exchange rate API directly?*, *Which package should I use?*, *Common use cases*).
- Replaced the provider name-drops in the intro and quickstart with a neutral default (`european_central_bank`, free, no API key). The example shows `// EUR → USD exchange rate` followed by an explicit `$amount * $rate->getValue()` step so the conversion is unambiguous.
- Reorganized the Providers table into **Public providers (no API key)** and **Commercial providers (require an API key)** groups, alphabetical within each. Added an **Identifier** column with the string actually passed to ``Builder::add()``, sourced from ``Exchanger\Service\Registry``.
- Simplified the Fixer rows: now two clearly labeled entries (`apilayer_fixer` for "Fixer (APILayer)", `fixer` for "Fixer (direct)").
- Fixed the stale `FlorianvSwapBundle` links (they now point to `florianv/symfony-swap`).
- Fixed the `Ukranie` typo.
- Added a cross-link block to Exchanger, Laravel Swap, and Symfony Swap.
- Added light, professional emojis to top-level section titles for visual scanning. Paragraphs, tables, and code blocks remain plain.

### `doc/readme.md`

- Replaced the legacy intro block at the top of the doc with a short *About this documentation* section that frames the doc against the README.
- Modernized the Installation example (PSR-18 first via `symfony/http-client`, Guzzle 7 alternative noted; `php-http/curl-client` is no longer the recommended path).
- Neutralized the Configuration example (`european_central_bank` as the default, no commercial provider name-drops).
- Added an explicit *How the fallback chain works* paragraph (skip on unsupported pair, retry on thrown exception, `ChainException` after all collected exceptions).
- Renamed the *Rate provider* subsection to *Inspecting the rate* and listed every method exposed on the returned `ExchangeRate`.
- Added a minimal Symfony Cache PSR-16 example before the existing Predis + PSR-6/PSR-16 bridge example, so the simple path is visible first.
- Updated the HTTP request caching example to use Guzzle 7 instead of the EOL `guzzle6-adapter`.
- Replaced the verbose *Supported Services* code dump with a focused *Provider configuration* table that maps each commercial identifier to its required option (`api_key`, `access_key`, `app_id`, `token`, `api-key`) and optional flags (`enterprise`, `paid`). Public providers and the `array` fixture are documented separately. The full provider list with capabilities now lives in the README's Providers table; the doc points to it instead of duplicating it.
- Added a short FAQ (what happens when every provider fails, can I use Swap without an API key, how do I cache rates, how do I disable cache for a single query, how do I add my own provider, where is the full provider list).
- Added light, professional emojis to top-level section titles, matching the README.

### `composer.json`

- Updated description and Packagist keywords (`currency conversion`, `currency conversion library`, `php currency conversion`, `exchange rate api`, `forex`, `forex api`).

## Why

- Clearer value proposition on the first screen.
- Quickstart that works end-to-end without an external account.
- Searchable terms (currency conversion, exchange rate API, forex API, PHP currency conversion) are now present in headings, the opening paragraph, and the Packagist metadata.
- Short factual sections are easy for both developers and LLMs to reference.
- The doc no longer duplicates the README's Providers table; it focuses on the parts the README cannot cover (per-provider config keys, fallback semantics, custom service, FAQ).

## What did NOT change

- No runtime code changes. Public API of ``Swap\Swap`` and ``Swap\Builder`` is unchanged.
- No changes to `src/`, `tests/`, CI, Psalm config, or php-cs-fixer config.
- The CHANGELOG was not touched (this is doc work, not a release).