### PR TITLE
docs: list unirate_api in provider tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Total Downloads](https://img.shields.io/packagist/dt/florianv/swap.svg?style=flat-square)](https://packagist.org/packages/florianv/swap)
 [![Version](http://img.shields.io/packagist/v/florianv/swap.svg?style=flat-square)](https://packagist.org/packages/florianv/swap)
 
-> _The easy-to-use PHP currency conversion library. Retrieve exchange rates from 30 providers, with caching and fallback. Maintained since 2014._
+> _The easy-to-use PHP currency conversion library. Retrieve exchange rates from 31 providers, with caching and fallback. Maintained since 2014._
 
 <table>
    <tr>
@@ -101,7 +101,7 @@ For amount conversion (including the [moneyphp/money](https://github.com/moneyph
 
 ## 📊 Providers
 
-Swap supports 30 exchange rate providers. Pass the **identifier** to `Builder::add()`.
+Swap supports 31 exchange rate providers. Pass the **identifier** to `Builder::add()`.
 
 ### Commercial providers (require an API key)
 
@@ -123,6 +123,7 @@ Swap supports 30 exchange rate providers. Pass the **identifier** to `Builder::a
 | Fixer (direct)                           | `fixer`                        | EUR (free), * (paid) | *     | Yes        |
 | 1Forge                                   | `forge`                        | *                    | *     | No         |
 | Open Exchange Rates                      | `open_exchange_rates`          | USD (free), * (paid) | *     | Yes        |
+| UniRateAPI                               | `unirate_api`                  | *                    | *     | Yes        |
 | WebserviceX                              | `webservicex`                  | *                    | *     | No         |
 | xChangeApi.com                           | `xchangeapi`                   | *                    | *     | Yes        |
 | Xignite                                  | `xignite`                      | *                    | *     | Yes        |
@@ -162,7 +163,7 @@ You can also add your own provider by implementing the `Exchanger\Contract\Excha
 The Swap ecosystem is a layered toolkit for currency conversion in PHP:
 
 - [**Swap**](https://github.com/florianv/swap). The easy-to-use, high-level API (this package).
-- [**Exchanger**](https://github.com/florianv/exchanger). Lower-level, more granular alternative; direct access to the 30 provider implementations and the `ExchangeRateService` interface.
+- [**Exchanger**](https://github.com/florianv/exchanger). Lower-level, more granular alternative; direct access to the 31 provider implementations and the `ExchangeRateService` interface.
 - [**Laravel Swap**](https://github.com/florianv/laravel-swap). Laravel application of Swap.
 - [**Symfony Swap**](https://github.com/florianv/symfony-swap). Symfony integration of Swap.
 

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -281,6 +281,7 @@ Commercial providers require an API key. The option name varies by provider. The
 | `fixer_apilayer`                 | `api_key`       |                       |
 | `forge`                          | `api_key`       |                       |
 | `open_exchange_rates`            | `app_id`        | `enterprise` (bool)   |
+| `unirate_api`                    | `api_key`       |                       |
 | `xchangeapi`                     | `api-key`       | (note the hyphen)     |
 | `xignite`                        | `token`         |                       |
 


### PR DESCRIPTION
Adds [UniRateAPI](https://unirateapi.com/) to the documented provider lists, following [florianv/exchanger#180](https://github.com/florianv/exchanger/pull/180) which landed the `UniRateApi` service and registered it under the identifier `unirate_api` in `Exchanger\Service\Registry`.

`Swap\Service\Registry` already pulls every entry from `ExchangerRegistry::getServices()`, so once Exchanger ships its next tagged release this is usable on master as-is:

```php
$swap = (new Builder())
    ->add('unirate_api', ['api_key' => getenv('UNIRATE_API_KEY')])
    ->build();
```

This PR only updates the docs.

### Changes

- **README.md** — adds `UniRateAPI` row to the commercial provider table, alphabetical between `open_exchange_rates` and `webservicex`; bumps the provider count `30 → 31` in three places (tagline, Providers section, sibling-package line for Exchanger).
- **doc/readme.md** — adds `unirate_api` / `api_key` to the commercial provider configuration table.

### Notes

- Identifier `unirate_api` matches the key used in Exchanger's `Registry::getServices()` after #180.
- UniRateAPI is a commercial REST API for FX (170+ currencies, EUR/USD/any base). Latest rates are available on the free tier; historical (`/api/historical`) and commodities are paid-tier only — the upstream `UniRateApi.php` maps HTTP 403 from those endpoints to `Exchanger\Exception\ChainException`, matching the existing fastFOREX / Fixer behaviour for plan-gated endpoints.

### Disclosure

I work with UniRateAPI. The implementation work (Exchanger #180) was done first; opening this docs PR now that the merge has landed so users can discover the provider through the standard table without needing to read the changelog. Happy to revise the wording or drop the count bump if you'd rather hold the count fixed until the next Exchanger release tag.
